### PR TITLE
fix: add Dockerfile for wiremock (#3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,9 @@ version: '3'
 
 services:
   wiremock:
-    image: wiremock/wiremock
+    build:
+      context: .
+      dockerfile: wiremock.Dockerfile
     command: "--verbose"
     ports:
       - "8080:8080"

--- a/wiremock.Dockerfile
+++ b/wiremock.Dockerfile
@@ -1,0 +1,1 @@
+FROM wiremock/wiremock:2.35.0-alpine


### PR DESCRIPTION
Dependabot does not support docker-compose at the moment.
See issue
- https://github.com/dependabot/dependabot-core/issues/390

As a workaround, a simple Dockerfile is added and docker-compose build functionality is used.
