### PR TITLE
chore(deps): bump wiremock from 2.35.0 to 3.0.0

### DIFF
--- a/mock-api/build.gradle.kts
+++ b/mock-api/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.http4k:http4k-core")
     implementation("org.http4k:http4k-client-apache")
 
-    implementation("com.github.tomakehurst:wiremock-jre8:2.35.0")
+    implementation("org.wiremock:wiremock:3.0.0")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("ch.qos.logback:logback-classic:1.4.11")
 }


### PR DESCRIPTION
Release: https://github.com/wiremock/wiremock/releases/tag/3.0.0
