### PR TITLE
chore(dependabot): use directories for gradle and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,16 @@ updates:
       prefix: "chore(action): "
 
   - package-ecosystem: "gradle"
-    directory: "/mock-api/"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(gradle): "
 
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "**/*"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
See also:
- https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directories
